### PR TITLE
Add return types to match newer Composer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "composer/installers": "^1.10"
     },
     "require-dev": {
-        "composer/composer": "^2.0.8",
+        "composer/composer": "^2.3.0",
         "phpstan/phpstan": "^1.9"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "composer/composer": "^2.0.8",
-        "phpstan/phpstan": "^0.12"
+        "phpstan/phpstan": "^1.9"
     },
     "suggest": {
         "szepeviktor/composer-theme-fusion": "Composer plugin for ThemeFusion"
@@ -34,5 +34,10 @@
     "scripts": {
         "lint": "find src/ -type f -name '*.php' -print0|xargs -0 -L1 -P4 -- php -l -f",
         "analyze": "phpstan analyze"
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }

--- a/src/EnvatoApi.php
+++ b/src/EnvatoApi.php
@@ -39,12 +39,12 @@ class EnvatoApi
 
         // TODO HTTP 429 response. Included in this response is a HTTP header Retry-After
         if ($response->getStatusCode() === 200) {
-            $versionData = \json_decode($response->getBody(), true);
+            $versionData = \json_decode($response->getBody() ?? '', true);
             // TODO Check JSON
-            if (\array_key_exists('wordpress_theme_latest_version', $versionData)) {
+            if (is_array($versionData) && \array_key_exists('wordpress_theme_latest_version', $versionData)) {
                 return $versionData['wordpress_theme_latest_version'];
             }
-            if (\array_key_exists('wordpress_plugin_latest_version', $versionData)) {
+            if (is_array($versionData) && \array_key_exists('wordpress_plugin_latest_version', $versionData)) {
                 return $versionData['wordpress_plugin_latest_version'];
             }
         }
@@ -62,12 +62,12 @@ class EnvatoApi
 
         // TODO HTTP 429 response. Included in this response is a HTTP header Retry-After
         if ($response->getStatusCode() === 200) {
-            $urlData = \json_decode($response->getBody(), true);
+            $urlData = \json_decode($response->getBody() ?? '', true);
             // TODO Check JSON
-            if (\array_key_exists('wordpress_theme', $urlData)) {
+            if (is_array($urlData) && \array_key_exists('wordpress_theme', $urlData)) {
                 return $urlData['wordpress_theme'];
             }
-            if (\array_key_exists('wordpress_plugin', $urlData)) {
+            if (is_array($urlData) && \array_key_exists('wordpress_plugin', $urlData)) {
                 return $urlData['wordpress_plugin'];
             }
         }

--- a/src/EnvatoPackage.php
+++ b/src/EnvatoPackage.php
@@ -50,7 +50,7 @@ class EnvatoPackage extends Package
     /**
      * {@inheritDoc}
      */
-    public function getDistType()
+    public function getDistType(): string
     {
         return 'zip';
     }
@@ -58,7 +58,7 @@ class EnvatoPackage extends Package
     /**
      * {@inheritDoc}
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         if ($this->version !== '0.0.0.0') {
             return $this->version;
@@ -75,7 +75,7 @@ class EnvatoPackage extends Package
     /**
      * {@inheritDoc}
      */
-    public function getPrettyVersion()
+    public function getPrettyVersion(): string
     {
         if ($this->prettyVersion !== '0.0.0') {
             return $this->prettyVersion;


### PR DESCRIPTION
I just updated the return type of the method `getDistType()` to a string and one other method which PHPStan flagged.  Also checked if some variable were null in `EnvatoApi.php`.  PHPstan is showing no errors up to level 6