### PR TITLE
Add support for loading personal token from environment variable or `.env` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ e.g. `https://themeforest.net/item/avada-responsive-multipurpose-theme/2833226`
 
 :bulb: Please use the vendor name `envato` for consistency.
 
-The personal token can also be read from an environment variable:
+The personal token can also be read from an environment variable or a `.env` file.
+Create a `.env` file, where the `composer.json` file lives, and add the following:
 
 ```
 ENVATO_TOKEN="<YOUR ENVATO PERSONAL TOKEN FROM https://build.envato.com/create-token>"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ e.g. `https://themeforest.net/item/avada-responsive-multipurpose-theme/2833226`
 
 :bulb: Please use the vendor name `envato` for consistency.
 
+The personal token can also be read from an environment variable:
+
+```
+ENVATO_TOKEN="<YOUR ENVATO PERSONAL TOKEN FROM https://build.envato.com/create-token>"
+```
+
 ### Usage
 
 Once the plugin is installed and configured,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "composer-plugin-api": "^2.0",
-        "composer/installers": "^1.10 || ^2.0"
+        "composer/installers": "^1.10 || ^2.0",
+        "vlucas/phpdotenv": "^4.3 || ^5.5"
     },
     "require-dev": {
         "composer/composer": "^2.3.0",

--- a/src/EnvatoConfig.php
+++ b/src/EnvatoConfig.php
@@ -10,6 +10,8 @@ class EnvatoConfig
 {
     public const ENVATO_CONFIG = 'envato';
 
+    public const ENV_VAR_TOKEN = 'ENVATO_TOKEN';
+
     /**
      * @var array<mixed>
      */
@@ -24,6 +26,8 @@ class EnvatoConfig
     {
         $envatoConfig = $composerConfig->get(self::ENVATO_CONFIG);
         $this->config = \is_array($envatoConfig) ? $envatoConfig : [];
+
+        $this->mergeEnvConfig();
 
         $this->valid = \array_key_exists('token', $this->config)
             && \is_string($this->config['token'])
@@ -62,5 +66,12 @@ class EnvatoConfig
             \array_keys($this->config['packages']),
             $this->config['packages']
         );
+    }
+
+    protected function mergeEnvConfig(): void
+    {
+        if (\array_key_exists(self::ENV_VAR_TOKEN, $_ENV)) {
+            $this->config['token'] = $_ENV[self::ENV_VAR_TOKEN];
+        }
     }
 }

--- a/src/EnvatoConfig.php
+++ b/src/EnvatoConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SzepeViktor\Composer\Envato;
 
 use Composer\Config;
+use Dotenv\Dotenv;
 
 class EnvatoConfig
 {
@@ -27,6 +28,7 @@ class EnvatoConfig
         $envatoConfig = $composerConfig->get(self::ENVATO_CONFIG);
         $this->config = \is_array($envatoConfig) ? $envatoConfig : [];
 
+        $this->loadDotenv();
         $this->mergeEnvConfig();
 
         $this->valid = \array_key_exists('token', $this->config)
@@ -66,6 +68,14 @@ class EnvatoConfig
             \array_keys($this->config['packages']),
             $this->config['packages']
         );
+    }
+
+    protected function loadDotenv(): void
+    {
+        $cwd = \getcwd();
+        if ($cwd && \file_exists($cwd . DIRECTORY_SEPARATOR . '.env')) {
+            Dotenv::createImmutable($cwd)->safeLoad();
+        }
     }
 
     protected function mergeEnvConfig(): void


### PR DESCRIPTION
Changed:

* Plugin requires [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv) v4 or v5.
* Config will load `Dotenv` if a `.env` file exists in the current working directory.
* Config will look for `$_ENV['ENVATO_TOKEN']`.

Alternatively, instead of requiring vlucas/phpdotenv, we could add conflict and suggest entries to the `composer.json` and check if the class exists before attempting to load Dotenv.