### PR TITLE
Fix Envato package dist/download URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "szepeviktor/composer-theme-fusion": "Composer plugin for ThemeFusion"
     },
     "extra": {
-        "class": "SzepeViktor\\Composer\\Envato\\EnvatoPlugin"
+        "class": "SzepeViktor\\Composer\\Envato\\EnvatoPlugin",
+        "plugin-modifies-downloads": true
     },
     "autoload": {
         "psr-4": {

--- a/src/EnvatoApi.php
+++ b/src/EnvatoApi.php
@@ -30,6 +30,11 @@ class EnvatoApi
         $this->token = $token;
     }
 
+    /**
+     * Query the Envato API for the item's current version.
+     *
+     * @return non-empty-string
+     */
     public function getVersion(int $itemId): string
     {
         $response = $this->httpDownloader->get(
@@ -57,9 +62,11 @@ class EnvatoApi
     }
 
     /**
-     * Uses the API request URL to retrieve th download URL
-     * as the package's dist URL to serve as its cache key.
+     * Return the Envato API URL to retrieve the item's download URL.
      *
+     * @param  int         $itemId  The item ID to lookup.
+     * @param  string|null $version Optional version to append to the URL.
+     *     This is used to by the plugin for the download's cache key in Composer.
      * @return non-empty-string
      */
     public function getDownloadRequestUrl(int $itemId, ?string $version = null): string
@@ -74,7 +81,9 @@ class EnvatoApi
     }
 
     /**
-     * @param  int|string $itemIdOrApiUrl
+     * Query the Envato API to retrieve the item's download URL.
+     *
+     * @param  int|string $itemIdOrApiUrl The item ID to lookup or the API URL to query.
      * @return non-empty-string|null
      */
     public function getDownloadUrl($itemIdOrApiUrl): ?string

--- a/src/EnvatoApi.php
+++ b/src/EnvatoApi.php
@@ -88,9 +88,15 @@ class EnvatoApi
      */
     public function getDownloadUrl($itemIdOrApiUrl): ?string
     {
-        if (\is_int($itemIdOrApiUrl) && $itemIdOrApiUrl > 0) {
+        if (
+            \is_int($itemIdOrApiUrl) &&
+            $itemIdOrApiUrl > 0
+        ) {
             $apiUrl = $this->getDownloadRequestUrl($itemIdOrApiUrl);
-        } elseif (\is_string($itemIdOrApiUrl) && $itemIdOrApiUrl !== '') {
+        } elseif (
+            \is_string($itemIdOrApiUrl) &&
+            \strpos($itemIdOrApiUrl, self::API_BASE_URL . '/market/buyer/download') !== false
+        ) {
             $apiUrl = $itemIdOrApiUrl;
         } else {
             return null;

--- a/src/EnvatoApi.php
+++ b/src/EnvatoApi.php
@@ -41,11 +41,14 @@ class EnvatoApi
         if ($response->getStatusCode() === 200) {
             $versionData = \json_decode($response->getBody() ?? '', true);
             // TODO Check JSON
-            if (is_array($versionData) && \array_key_exists('wordpress_theme_latest_version', $versionData)) {
-                return $versionData['wordpress_theme_latest_version'];
-            }
-            if (is_array($versionData) && \array_key_exists('wordpress_plugin_latest_version', $versionData)) {
-                return $versionData['wordpress_plugin_latest_version'];
+            if (\is_array($versionData)) {
+                if (\array_key_exists('wordpress_theme_latest_version', $versionData)) {
+                    return $versionData['wordpress_theme_latest_version'];
+                }
+
+                if (\array_key_exists('wordpress_plugin_latest_version', $versionData)) {
+                    return $versionData['wordpress_plugin_latest_version'];
+                }
             }
         }
 
@@ -67,11 +70,14 @@ class EnvatoApi
         if ($response->getStatusCode() === 200) {
             $urlData = \json_decode($response->getBody() ?? '', true);
             // TODO Check JSON
-            if (is_array($urlData) && \array_key_exists('wordpress_theme', $urlData)) {
-                return $urlData['wordpress_theme'];
-            }
-            if (is_array($urlData) && \array_key_exists('wordpress_plugin', $urlData)) {
-                return $urlData['wordpress_plugin'];
+            if (\is_array($urlData)) {
+                if (\array_key_exists('wordpress_theme', $urlData)) {
+                    return $urlData['wordpress_theme'];
+                }
+
+                if (\array_key_exists('wordpress_plugin', $urlData)) {
+                    return $urlData['wordpress_plugin'];
+                }
             }
         }
 

--- a/src/EnvatoApi.php
+++ b/src/EnvatoApi.php
@@ -57,12 +57,38 @@ class EnvatoApi
     }
 
     /**
+     * Uses the API request URL to retrieve th download URL
+     * as the package's dist URL to serve as its cache key.
+     *
+     * @return non-empty-string
+     */
+    public function getDownloadRequestUrl(int $itemId, ?string $version = null): string
+    {
+        $query = ['item_id' => $itemId];
+
+        if ($version !== null) {
+            $query['version'] = $version;
+        }
+
+        return self::API_BASE_URL . '/market/buyer/download?' . \http_build_query($query);
+    }
+
+    /**
+     * @param  int|string $itemIdOrApiUrl
      * @return non-empty-string|null
      */
-    public function getDownloadUrl(int $itemId): ?string
+    public function getDownloadUrl($itemIdOrApiUrl): ?string
     {
+        if (\is_int($itemIdOrApiUrl) && $itemIdOrApiUrl > 0) {
+            $apiUrl = $this->getDownloadRequestUrl($itemIdOrApiUrl);
+        } elseif (\is_string($itemIdOrApiUrl) && $itemIdOrApiUrl !== '') {
+            $apiUrl = $itemIdOrApiUrl;
+        } else {
+            return null;
+        }
+
         $response = $this->httpDownloader->get(
-            self::API_BASE_URL . '/market/buyer/download?' . \http_build_query(['item_id' => $itemId]),
+            $apiUrl,
             ['http' => ['header' => ['Authorization: Bearer ' . $this->token]]]
         );
 

--- a/src/EnvatoConfig.php
+++ b/src/EnvatoConfig.php
@@ -14,7 +14,7 @@ class EnvatoConfig
     public const ENV_VAR_TOKEN = 'ENVATO_TOKEN';
 
     /**
-     * @var array<mixed>
+     * @var array{token?:string, packages?:array{item-id:?(int|string), type:?string}}
      */
     protected $config;
 
@@ -40,6 +40,9 @@ class EnvatoConfig
         ;
     }
 
+    /**
+     * @phpstan-assert-if-true !array{} $this->config
+     */
     public function isValid(): bool
     {
         return $this->valid;
@@ -60,9 +63,9 @@ class EnvatoConfig
         return \array_map(
             static function ($name, $data) {
                 return [
-                    'name' => (string)$name,
-                    'itemId' => $data['item-id'] ?? 0,
-                    'type' => $data['type'] ?? 'wordpress-theme',
+                    'name'   => (string)$name,
+                    'itemId' => (int)($data['item-id'] ?? 0),
+                    'type'   => (string)($data['type'] ?? 'wordpress-theme'),
                 ];
             },
             \array_keys($this->config['packages']),

--- a/src/EnvatoConfig.php
+++ b/src/EnvatoConfig.php
@@ -14,7 +14,7 @@ class EnvatoConfig
     public const ENV_VAR_TOKEN = 'ENVATO_TOKEN';
 
     /**
-     * @var array{token?:string, packages?:array{item-id:?(int|string), type:?string}}
+     * @var array{token?:string, packages?:array{item-id:int|string|null, type:string|null}}
      */
     protected $config;
 

--- a/src/EnvatoPackage.php
+++ b/src/EnvatoPackage.php
@@ -87,7 +87,7 @@ class EnvatoPackage extends Package
             return $this->distUrl;
         }
 
-        $this->distUrl = $this->api->getDownloadUrl($this->itemId);
+        $this->distUrl = $this->api->getDownloadRequestUrl($this->itemId, $this->getPrettyVersion());
 
         return $this->distUrl;
     }

--- a/src/EnvatoPackage.php
+++ b/src/EnvatoPackage.php
@@ -51,10 +51,7 @@ class EnvatoPackage extends Package
             return $this->version;
         }
 
-        // Query Envato API
-        $this->prettyVersion = $this->api->getVersion($this->itemId);
-        $versionParser = new VersionParser();
-        $this->version = $versionParser->normalize($this->prettyVersion);
+        $this->processItemVersion();
 
         return $this->version;
     }
@@ -68,10 +65,7 @@ class EnvatoPackage extends Package
             return $this->prettyVersion;
         }
 
-        // Query Envato API
-        $this->prettyVersion = $this->api->getVersion($this->itemId);
-        $versionParser = new VersionParser();
-        $this->version = $versionParser->normalize($this->prettyVersion);
+        $this->processItemVersion();
 
         return $this->prettyVersion;
     }
@@ -104,5 +98,13 @@ class EnvatoPackage extends Package
     public function isAbandoned()
     {
         return false;
+    }
+
+    protected function processItemVersion(): void
+    {
+        // Query Envato API
+        $this->prettyVersion = $this->api->getVersion($this->itemId);
+        $versionParser = new VersionParser();
+        $this->version = $versionParser->normalize($this->prettyVersion);
     }
 }

--- a/src/EnvatoPackage.php
+++ b/src/EnvatoPackage.php
@@ -87,6 +87,10 @@ class EnvatoPackage extends Package
             return $this->distUrl;
         }
 
+        /**
+         * Use the Envato API URL to retrieve the item's download URL
+         * as the package's dist URL to serve as its cache key.
+         */
         $this->distUrl = $this->api->getDownloadRequestUrl($this->itemId, $this->getPrettyVersion());
 
         return $this->distUrl;
@@ -100,6 +104,9 @@ class EnvatoPackage extends Package
         return false;
     }
 
+    /**
+     * Retrieve the item's version from the Envato API.
+     */
     protected function processItemVersion(): void
     {
         // Query Envato API

--- a/src/EnvatoPlugin.php
+++ b/src/EnvatoPlugin.php
@@ -96,7 +96,8 @@ class EnvatoPlugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * Resolve the download URL before downloading the package.
+     * Retrieve the item's download URL from the Envato API
+     * and use the item's dist URL as the cache key.
      */
     public function handlePreDownloadEvent(PreFileDownloadEvent $event): void
     {


### PR DESCRIPTION
Resolves #2

## Issue

When generating the Composer packages for the virtual repository from the configured list of Envato products, this plugin would retrieve the product's download URL via Envato's API and assign it as the package's dist URL. Composer uses this URL as the download's cache key and package URL in a project's `composer.lock` for later installations.

Unfortunately, this download URL is signed and expires quickly. This is problematic if ever Composer's cache is cleared or if the project is installed on a different server where Composer's cache is not mirrored.

### Example

Given this configuration:

```json
"config": {
	"envato": {
		"token": "…",
		"packages": {
			"envato/devowl-real-media-library": {
				"item-id": 13155134,
				"type": "wordpress-plugin"
			}
		}
	}
}
```

When this Envato product is installed, the plugin creates a Composer package and for its `dist.url`, it queries the Envato API for the download URL:

API Request URI:

```
https://api.envato.com/v3/market/buyer/download?item_id=13155134
```

The API responds with a temporary download URL:

```
https://marketplace-downloads.customer.envatousercontent.com/files/13155134/real-media-library-4.18.31.installable.zip?response-content-dispositio…
```

This results in the following entry in your project's `composer.lock`:

```json
"packages": [
	{
		"name": "envato/devowl-real-media-library",
		"version": "4.18.31",
		"dist": {
			"type": "zip",
			"url": "https://marketplace-downloads.customer.envatousercontent.com/files/13155134/real-media-library-4.18.31.installable.zip?response-content-dispositio…"
		},
		"type": "wordpress-plugin"
	}
]
```

By default, Composer uses the `dist.url` as both the download URL and that download's cache key. When first retrieving this download URL from the Envato API, the URL is valid, the plugin is downloaded and cached under that same URL.

When the cached download is missing, Composer attempts to download the package from that same URL which is now expired. That's why the URL responds with "Authentication required".

To bypass this expired URL requires removing the package from the `composer.lock` to get Composer to ask the plugin for a (new) download URL.

## Solution

This is resolved by assigning a more stable versioned dist URL (at this time, the API request URL to retrieve the download URL) and telling Composer that this plugin needs to update package download URLs before they are downloaded (`extra.plugin-modifies-downloads`).

Then, during the `pre-file-download` event, this plugin will retrieve the download URL from Envato's API while using the stable dist URL as the cache key.

### Example

Using the same configuration as above, when the plugin creates a Composer package, its `dist.url` is now assigned the URL that queries Envato API for the download URL _instead of_ the final download URL.

This results in the following entry in your project's `composer.lock`:

```json
"packages": [
	{
		"name": "envato/devowl-real-media-library",
		"version": "4.18.31",
		"dist": {
			"type": "zip",
			"url": "https://api.envato.com/v3/market/buyer/download?item_id=13155134&version=4.18.31"
		},
		"type": "wordpress-plugin"
	}
]
```

This "static" `dist.url`, which also includes the package's version, is used as the cache key to ensure the cache is specific to each version.

When Composer attempts to download packages, this plugin will use the `dist.url` (if it matches the Envato API URI) to retrieve the temporary download URL and cache the ZIP against the cache key generated from the static URL.

## Testing

I've also fixed some errors reported by PHPStan, from 6 down to 3:

```
------ ---------------------------------------------------------------------------------------------------------------------------
 Line   EnvatoConfig.php
------ ---------------------------------------------------------------------------------------------------------------------------
 53     Offset 'token' does not exist on array{token?: string, packages?: array{item-id: int|string|null, type: string|null}}.
 71     Offset 'packages' does not exist on array{token?: string, packages?: array{item-id: int|string|null, type: string|null}}.
 72     Offset 'packages' does not exist on array{token?: string, packages?: array{item-id: int|string|null, type: string|null}}.
------ ---------------------------------------------------------------------------------------------------------------------------
```

The last 3 should resolve themselves whenever this issue is fixed: [phpstan/phpstan#8382](https://github.com/phpstan/phpstan/issues/8382).