### PR TITLE
Ensure the config is valid before subscribing to events

### DIFF
--- a/src/EnvatoPlugin.php
+++ b/src/EnvatoPlugin.php
@@ -71,6 +71,10 @@ class EnvatoPlugin implements PluginInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
+        if (! $this->config->isValid()) {
+            return [];
+        }
+
         return [
             PluginEvents::PRE_FILE_DOWNLOAD => [ 'handlePreDownloadEvent', -1 ],
         ];


### PR DESCRIPTION
Prevents an error in [`EnvatoPlugin`](https://github.com/szepeviktor/composer-envato/blob/v1.1.0/src/EnvatoPlugin.php#L114):

> Call to a member function `getDownloadUrl()` on null

This error is the result of the `EnvatoApi` not being set up when the config is invalid but events still being subscribed to.