### PR TITLE
Fix config validation for subscribed event

### DIFF
--- a/src/EnvatoPlugin.php
+++ b/src/EnvatoPlugin.php
@@ -71,10 +71,6 @@ class EnvatoPlugin implements PluginInterface, EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        if (! $this->config->isValid()) {
-            return [];
-        }
-
         return [
             PluginEvents::PRE_FILE_DOWNLOAD => [ 'handlePreDownloadEvent', -1 ],
         ];
@@ -105,12 +101,7 @@ class EnvatoPlugin implements PluginInterface, EventSubscriberInterface
      */
     public function handlePreDownloadEvent(PreFileDownloadEvent $event): void
     {
-        /**
-         * Bail early if this event is not for a package.
-         *
-         * @see https://github.com/composer/composer/pull/8975
-         */
-        if ($event->getType() !== 'package') {
+        if (! $this->config->isValid() || $event->getType() !== 'package') {
             return;
         }
 


### PR DESCRIPTION
Amends #16

As mentioned in a [comment of that pull request](https://github.com/szepeviktor/composer-envato/pull/16#issuecomment-1452300619), the `EnvatoPlugin::getSubscribedEvents()` method is static preventing us from checking the instance property `$config`.

I've moved the config validation check to `handlePreDownloadEvent()`.

### Testing

I've tested the code in practice and I've run PHPStan which reports only the existing issues with `EnvatoConfig`.