### PR TITLE
Fix: Add fallback to OS environment variables

### DIFF
--- a/src/EnvatoConfig.php
+++ b/src/EnvatoConfig.php
@@ -83,8 +83,14 @@ class EnvatoConfig
 
     protected function mergeEnvConfig(): void
     {
-        if (\array_key_exists(self::ENV_VAR_TOKEN, $_ENV)) {
+        if (!empty($_ENV[self::ENV_VAR_TOKEN])) {
             $this->config['token'] = $_ENV[self::ENV_VAR_TOKEN];
+            return;
+        }
+
+        $token = \getenv(self::ENV_VAR_TOKEN);
+        if ($token !== false && $token !== '') {
+            $this->config['token'] = $token;
         }
     }
 }


### PR DESCRIPTION
The current implementation only works with .env files but completely ignores when the ENVATO_TOKEN env. variable is set in the OS, i.e., by a CI pipeline.

The fix provided in the PR, adds a fallback to the OS variables, in case $_ENV or the key does not exist.